### PR TITLE
Bump react-scripts from 4.0.3 to 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-redux": "^7.2.4",
-    "react-scripts": "4.0.3",
+    "react-scripts": "^5.0.1",
     "react-simple-code-editor": "^0.11.0",
     "react-toastify": "^7.0.4",
     "redux": "^4.1.0",


### PR DESCRIPTION
## Problem

When using node > 16 version to run `npm start`, the following error will happen:

```console
$ npm start
Starting the development server...

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:67:19)
    at Object.createHash (node:crypto:133:10)
    at module.exports (/Users/feng/dev/jiset/web/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/Users/feng/dev/jiset/web/node_modules/webpack/lib/NormalModule.js:417:16)
    at handleParseError (/Users/feng/dev/jiset/web/node_modules/webpack/lib/NormalModule.js:471:10)
    at /Users/feng/dev/jiset/web/node_modules/webpack/lib/NormalModule.js:503:5
    at /Users/feng/dev/jiset/web/node_modules/webpack/lib/NormalModule.js:358:12
    at /Users/feng/dev/jiset/web/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (/Users/feng/dev/jiset/web/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at iterateNormalLoaders (/Users/feng/dev/jiset/web/node_modules/loader-runner/lib/LoaderRunner.js:221:10)
/Users/feng/dev/jiset/web/node_modules/react-scripts/scripts/start.js:19
  throw err;
  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:67:19)
    at Object.createHash (node:crypto:133:10)
    at module.exports (/Users/feng/dev/jiset/web/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/Users/feng/dev/jiset/web/node_modules/webpack/lib/NormalModule.js:417:16)
    at /Users/feng/dev/jiset/web/node_modules/webpack/lib/NormalModule.js:452:10
    at /Users/feng/dev/jiset/web/node_modules/webpack/lib/NormalModule.js:323:13
    at /Users/feng/dev/jiset/web/node_modules/loader-runner/lib/LoaderRunner.js:367:11
    at /Users/feng/dev/jiset/web/node_modules/loader-runner/lib/LoaderRunner.js:233:18
    at context.callback (/Users/feng/dev/jiset/web/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at /Users/feng/dev/jiset/web/node_modules/babel-loader/lib/index.js:59:103 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}

Node.js v18.2.0
```

This issue is caused by webpack v4 and fixed by webpack v5, see this issue for details: https://github.com/webpack/webpack/issues/14532

## Solution

Bump react-scripts version to v5 which use webpack v5

## Extra info

This pr is same as https://github.com/kaist-plrg/jiset/pull/220